### PR TITLE
Switch Node example to SQLite

### DIFF
--- a/library-system/README.md
+++ b/library-system/README.md
@@ -11,6 +11,8 @@ npm start
 
 Sunucu calistiktan sonra kitap, kullanici ve odunc islemleri icin `/api/books`, `/api/users` ve `/api/borrow` adreslerini kullanabilirsiniz.
 
+`POST /api/borrow` uzerinden okul numarasi ve ISBN gondererek kitap odunc alabilirsiniz. `PUT /api/borrow/:id/return` ile kitap iade edilir ve kitap adedi otomatik guncellenir.
+
 ### Excel Aktarim
 - `/api/books/export` ve `/api/users/export` tum kayitlari Excel dosyasi olarak indirir.
 - `/api/books/import` ve `/api/users/import` yollarina Excel dosyasi gondererek toplu veri ekleyebilirsiniz. Dosya gonderiminde `file` alanini kullanin.
@@ -46,3 +48,4 @@ Sunucu calistiktan sonra kitap, kullanici ve odunc islemleri icin `/api/books`, 
 - `borrowDate`
 - `dueDate`
 - `returnDate`
+  - `returnDate` (iade tarihi)

--- a/library-system/README.md
+++ b/library-system/README.md
@@ -1,0 +1,48 @@
+# Kutuphane Otomasyonu (Node.js + SQLite)
+
+Bu klasor, SQLite kullanarak gelistirilmis gelismis bir kutuphane otomasyonu icermektedir. Kitaplar, uyeler ve islem kayitlari icin detayli alanlar bulunur.
+
+## Calistirma
+
+```bash
+npm install
+npm start
+```
+
+Sunucu calistiktan sonra kitap, kullanici ve odunc islemleri icin `/api/books`, `/api/users` ve `/api/borrow` adreslerini kullanabilirsiniz.
+
+### Excel Aktarim
+- `/api/books/export` ve `/api/users/export` tum kayitlari Excel dosyasi olarak indirir.
+- `/api/books/import` ve `/api/users/import` yollarina Excel dosyasi gondererek toplu veri ekleyebilirsiniz. Dosya gonderiminde `file` alanini kullanin.
+
+### ISBN'den Bilgi Cekme
+- `/api/books/fetch/:isbn` adresi verilen ISBN icin Google Books veya Open Library servislerinden kitap bilgilerini ceker.
+
+### Kitap Alanlari
+- `isbn`
+- `baslik`
+- `yazar`
+- `yayinevi`
+- `baski_yili`
+- `sayfa_sayisi`
+- `resim` (URL)
+- `raf`
+- `kategori`
+- `mevcut`
+
+### Uye Alanlari
+- `ad`
+- `soyad`
+- `sinif`
+- `sube`
+- `okul_no`
+- `email`
+- `tel`
+- `rol` (ogrenci/ogretmen)
+
+### Islem Alanlari
+- `okul_no`
+- `isbn`
+- `borrowDate`
+- `dueDate`
+- `returnDate`

--- a/library-system/db.js
+++ b/library-system/db.js
@@ -1,0 +1,47 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const db = new sqlite3.Database(path.join(__dirname, 'library.db'));
+
+function init() {
+  db.serialize(() => {
+    db.run(`CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ad TEXT NOT NULL,
+      soyad TEXT NOT NULL,
+      sinif TEXT,
+      sube TEXT,
+      okul_no INTEGER,
+      email TEXT UNIQUE,
+      tel TEXT,
+      rol TEXT DEFAULT 'ogrenci'
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS books (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      isbn TEXT UNIQUE,
+      baslik TEXT NOT NULL,
+      yazar TEXT,
+      yayinevi TEXT,
+      baski_yili INTEGER,
+      sayfa_sayisi INTEGER,
+      resim TEXT,
+      raf TEXT,
+      kategori TEXT,
+      mevcut INTEGER DEFAULT 1
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS borrow (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      userId INTEGER NOT NULL,
+      bookId INTEGER NOT NULL,
+      borrowDate TEXT DEFAULT CURRENT_TIMESTAMP,
+      dueDate TEXT,
+      returnDate TEXT,
+      FOREIGN KEY(userId) REFERENCES users(id),
+      FOREIGN KEY(bookId) REFERENCES books(id)
+    )`);
+  });
+}
+
+module.exports = { db, init };

--- a/library-system/package.json
+++ b/library-system/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "library-system",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.2",
+    "multer": "^1.4.5-lts.1",
+    "node-fetch": "^2.6.11",
+    "xlsx": "^0.18.5"
+  }
+}

--- a/library-system/routes/books.js
+++ b/library-system/routes/books.js
@@ -1,0 +1,168 @@
+const express = require('express');
+const router = express.Router();
+const { db } = require('../db');
+const multer = require('multer');
+const xlsx = require('xlsx');
+const fetch = require('node-fetch');
+const fs = require('fs');
+
+const upload = multer({ dest: 'uploads/' });
+
+// Yeni kitap ekle
+router.post('/', (req, res) => {
+  const {
+    isbn,
+    baslik,
+    yazar,
+    yayinevi,
+    baski_yili,
+    sayfa_sayisi,
+    resim,
+    raf,
+    kategori,
+    mevcut
+  } = req.body;
+
+  const stmt = db.prepare(
+    `INSERT INTO books (isbn, baslik, yazar, yayinevi, baski_yili, sayfa_sayisi, resim, raf, kategori, mevcut)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  );
+  stmt.run(
+    isbn,
+    baslik,
+    yazar,
+    yayinevi,
+    baski_yili,
+    sayfa_sayisi,
+    resim,
+    raf,
+    kategori,
+    mevcut || 1,
+    function (err) {
+      if (err) {
+        return res.status(400).json({ error: err.message });
+      }
+      res.status(201).json({
+        id: this.lastID,
+        isbn,
+        baslik,
+        yazar,
+        yayinevi,
+        baski_yili,
+        sayfa_sayisi,
+        resim,
+        raf,
+        kategori,
+        mevcut: mevcut || 1
+      });
+    }
+  );
+  stmt.finalize();
+});
+
+// Tum kitaplari listele
+router.get('/', (req, res) => {
+  db.all('SELECT * FROM books', (err, rows) => {
+    if (err) {
+      return res.status(500).json({ error: err.message });
+    }
+    res.json(rows);
+  });
+});
+
+// Tum kitaplari Excel olarak indir
+router.get('/export', (req, res) => {
+  db.all('SELECT * FROM books', (err, rows) => {
+    if (err) {
+      return res.status(500).json({ error: err.message });
+    }
+    const wb = xlsx.utils.book_new();
+    const ws = xlsx.utils.json_to_sheet(rows);
+    xlsx.utils.book_append_sheet(wb, ws, 'Kitaplar');
+    const buf = xlsx.write(wb, { type: 'buffer', bookType: 'xlsx' });
+    res.setHeader(
+      'Content-Disposition',
+      'attachment; filename="books.xlsx"'
+    );
+    res.type(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    );
+    res.send(buf);
+  });
+});
+
+// Excelden kitap yukle
+router.post('/import', upload.single('file'), (req, res) => {
+  try {
+    const wb = xlsx.readFile(req.file.path);
+    const sheet = wb.Sheets[wb.SheetNames[0]];
+    const data = xlsx.utils.sheet_to_json(sheet);
+    const stmt = db.prepare(
+      `INSERT INTO books (isbn, baslik, yazar, yayinevi, baski_yili, sayfa_sayisi, resim, raf, kategori, mevcut) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    data.forEach(row => {
+      stmt.run(
+        row.isbn,
+        row.baslik,
+        row.yazar,
+        row.yayinevi,
+        row.baski_yili,
+        row.sayfa_sayisi,
+        row.resim,
+        row.raf,
+        row.kategori,
+        row.mevcut || 1
+      );
+    });
+    stmt.finalize();
+    fs.unlinkSync(req.file.path);
+    res.json({ message: 'Yukleme tamamlandi', count: data.length });
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+// ISBN ile Google Books/Open Library'den veri cek
+router.get('/fetch/:isbn', async (req, res) => {
+  const { isbn } = req.params;
+  try {
+    let info = null;
+    const google = await fetch(
+      `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`
+    ).then(r => r.json());
+    if (google.totalItems > 0) {
+      const volume = google.items[0].volumeInfo;
+      info = {
+        baslik: volume.title,
+        yazar: (volume.authors || []).join(', '),
+        yayinevi: volume.publisher,
+        baski_yili: volume.publishedDate,
+        sayfa_sayisi: volume.pageCount,
+        resim: volume.imageLinks ? volume.imageLinks.thumbnail : null
+      };
+    } else {
+      const ol = await fetch(
+        `https://openlibrary.org/api/books?bibkeys=ISBN:${isbn}&jscmd=data&format=json`
+      ).then(r => r.json());
+      const record = ol[`ISBN:${isbn}`];
+      if (record) {
+        info = {
+          baslik: record.title,
+          yazar: record.authors ? record.authors.map(a => a.name).join(', ') : '',
+          yayinevi: record.publishers ? record.publishers.map(p => p.name).join(', ') : '',
+          baski_yili: record.publish_date,
+          sayfa_sayisi: record.number_of_pages,
+          resim: record.cover ? record.cover.medium : null
+        };
+      }
+    }
+    if (!info) {
+      return res.status(404).json({ error: 'Kayit bulunamadi' });
+    }
+    res.json(info);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+module.exports = router;

--- a/library-system/routes/borrow.js
+++ b/library-system/routes/borrow.js
@@ -1,0 +1,63 @@
+const express = require('express');
+const router = express.Router();
+const { db } = require('../db');
+
+// Kitap odunc al
+router.post('/', (req, res) => {
+  const { okul_no, isbn, borrowDate, dueDate, returnDate } = req.body;
+
+  db.get('SELECT id FROM users WHERE okul_no = ?', [okul_no], (err, userRow) => {
+    if (err || !userRow) {
+      return res.status(400).json({ error: 'Kullanici bulunamadi' });
+    }
+
+    db.get('SELECT id FROM books WHERE isbn = ?', [isbn], (err2, bookRow) => {
+      if (err2 || !bookRow) {
+        return res.status(400).json({ error: 'Kitap bulunamadi' });
+      }
+
+      const stmt = db.prepare(
+        'INSERT INTO borrow (userId, bookId, borrowDate, dueDate, returnDate) VALUES (?, ?, ?, ?, ?)'
+      );
+      stmt.run(
+        userRow.id,
+        bookRow.id,
+        borrowDate || new Date().toISOString(),
+        dueDate || null,
+        returnDate || null,
+        function (err3) {
+          if (err3) {
+            return res.status(400).json({ error: err3.message });
+          }
+          res.status(201).json({
+            id: this.lastID,
+            userId: userRow.id,
+            bookId: bookRow.id,
+            borrowDate: borrowDate || new Date().toISOString(),
+            dueDate,
+            returnDate
+          });
+        }
+      );
+      stmt.finalize();
+    });
+  });
+});
+
+// Odunc kayitlarini listele
+router.get('/', (req, res) => {
+  const query = `SELECT b.id, b.userId, b.bookId, b.borrowDate, b.dueDate, b.returnDate,
+    u.ad || ' ' || u.soyad AS kullanici,
+    bo.baslik AS kitap
+    FROM borrow b
+    LEFT JOIN users u ON b.userId = u.id
+    LEFT JOIN books bo ON b.bookId = bo.id`;
+  db.all(query, (err, rows) => {
+    if (err) {
+      return res.status(500).json({ error: err.message });
+    }
+    res.json(rows);
+  });
+});
+
+module.exports = router;

--- a/library-system/routes/borrow.js
+++ b/library-system/routes/borrow.js
@@ -11,10 +11,14 @@ router.post('/', (req, res) => {
       return res.status(400).json({ error: 'Kullanici bulunamadi' });
     }
 
-    db.get('SELECT id FROM books WHERE isbn = ?', [isbn], (err2, bookRow) => {
-      if (err2 || !bookRow) {
-        return res.status(400).json({ error: 'Kitap bulunamadi' });
-      }
+  db.get('SELECT id, mevcut FROM books WHERE isbn = ?', [isbn], (err2, bookRow) => {
+    if (err2 || !bookRow) {
+      return res.status(400).json({ error: 'Kitap bulunamadi' });
+    }
+
+    if (bookRow.mevcut <= 0) {
+      return res.status(400).json({ error: 'Kitap mevcut degil' });
+    }
 
       const stmt = db.prepare(
         'INSERT INTO borrow (userId, bookId, borrowDate, dueDate, returnDate) VALUES (?, ?, ?, ?, ?)'
@@ -37,6 +41,7 @@ router.post('/', (req, res) => {
             dueDate,
             returnDate
           });
+          db.run('UPDATE books SET mevcut = mevcut - 1 WHERE id = ?', [bookRow.id]);
         }
       );
       stmt.finalize();
@@ -57,6 +62,28 @@ router.get('/', (req, res) => {
       return res.status(500).json({ error: err.message });
     }
     res.json(rows);
+  });
+});
+
+// Kitabi iade et
+router.put('/:id/return', (req, res) => {
+  const { id } = req.params;
+  const returnDate = new Date().toISOString();
+
+  db.get('SELECT bookId, returnDate FROM borrow WHERE id = ?', [id], (err, row) => {
+    if (err || !row) {
+      return res.status(404).json({ error: 'Kayit bulunamadi' });
+    }
+    if (row.returnDate) {
+      return res.status(400).json({ error: 'Kitap zaten iade edilmis' });
+    }
+    db.run('UPDATE borrow SET returnDate = ? WHERE id = ?', [returnDate, id], err2 => {
+      if (err2) {
+        return res.status(400).json({ error: err2.message });
+      }
+      db.run('UPDATE books SET mevcut = mevcut + 1 WHERE id = ?', [row.bookId]);
+      res.json({ id: parseInt(id, 10), returnDate });
+    });
   });
 });
 

--- a/library-system/routes/users.js
+++ b/library-system/routes/users.js
@@ -1,0 +1,104 @@
+const express = require('express');
+const router = express.Router();
+const { db } = require('../db');
+const multer = require('multer');
+const xlsx = require('xlsx');
+const fs = require('fs');
+
+const upload = multer({ dest: 'uploads/' });
+// Kullanici kaydet
+router.post('/', (req, res) => {
+  const {
+    ad,
+    soyad,
+    sinif,
+    sube,
+    okul_no,
+    email,
+    tel,
+    rol
+  } = req.body;
+
+  const stmt = db.prepare(
+    'INSERT INTO users (ad, soyad, sinif, sube, okul_no, email, tel, rol) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+  );
+  stmt.run(ad, soyad, sinif, sube, okul_no, email, tel, rol || 'ogrenci', function (err) {
+    if (err) {
+      return res.status(400).json({ error: err.message });
+    }
+    res.status(201).json({
+      id: this.lastID,
+      ad,
+      soyad,
+      sinif,
+      sube,
+      okul_no,
+      email,
+      tel,
+      rol: rol || 'ogrenci'
+    });
+  });
+  stmt.finalize();
+});
+
+// Kullanici listesini getir
+router.get('/', (req, res) => {
+  db.all('SELECT * FROM users', (err, rows) => {
+    if (err) {
+      return res.status(500).json({ error: err.message });
+    }
+    res.json(rows);
+  });
+});
+
+// Tum uyeleri Excel olarak indir
+router.get('/export', (req, res) => {
+  db.all('SELECT * FROM users', (err, rows) => {
+    if (err) {
+      return res.status(500).json({ error: err.message });
+    }
+    const wb = xlsx.utils.book_new();
+    const ws = xlsx.utils.json_to_sheet(rows);
+    xlsx.utils.book_append_sheet(wb, ws, 'Uyeler');
+    const buf = xlsx.write(wb, { type: 'buffer', bookType: 'xlsx' });
+    res.setHeader(
+      'Content-Disposition',
+      'attachment; filename="users.xlsx"'
+    );
+    res.type(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    );
+    res.send(buf);
+  });
+});
+
+// Excelden uye yukle
+router.post('/import', upload.single('file'), (req, res) => {
+  try {
+    const wb = xlsx.readFile(req.file.path);
+    const sheet = wb.Sheets[wb.SheetNames[0]];
+    const data = xlsx.utils.sheet_to_json(sheet);
+    const stmt = db.prepare(
+      'INSERT INTO users (ad, soyad, sinif, sube, okul_no, email, tel, rol) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+    );
+  data.forEach(row => {
+      stmt.run(
+        row.ad,
+        row.soyad,
+        row.sinif,
+        row.sube,
+        row.okul_no,
+        row.email,
+        row.tel,
+        row.rol || 'ogrenci'
+      );
+  });
+  stmt.finalize();
+  fs.unlinkSync(req.file.path);
+  res.json({ message: 'Yukleme tamamlandi', count: data.length });
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+module.exports = router;

--- a/library-system/server.js
+++ b/library-system/server.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const { init } = require('./db');
+
+const bookRoutes = require('./routes/books');
+const userRoutes = require('./routes/users');
+const borrowRoutes = require('./routes/borrow');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// SQLite veritabani tablolari olusturuluyor
+init();
+
+app.use(bodyParser.json());
+app.use('/api/books', bookRoutes);
+app.use('/api/users', userRoutes);
+app.use('/api/borrow', borrowRoutes);
+
+app.listen(PORT, () => console.log(`Sunucu ${PORT} portunda calisiyor`));


### PR DESCRIPTION
## Summary
- migrate library-system from MongoDB to SQLite
- add DB initialization in `db.js`
- rewrite routes to use SQL queries
- update dependencies and documentation
- expand tables and routes with Turkish field names
- add Excel import/export and ISBN lookup endpoints

## Testing
- `npm install` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6846d62bc89c832bbb25247b238c7c00